### PR TITLE
Adapt to new reservation status names

### DIFF
--- a/src/api/action.js
+++ b/src/api/action.js
@@ -30,8 +30,11 @@ export async function reserve(track_id, date_str, time_id) {
     handle_redirect(res);
 
     let data = await res.json();
-    if(data.e!==0)
+    if(data.e!==0) {
+        if(data.m==='同一时间段不可重复预约')
+            return;
         throw new Error(`${data.e}: ${data.m}`);
+    }
 
     //window.alert(data.m);
 

--- a/src/data/common.js
+++ b/src/data/common.js
@@ -27,7 +27,7 @@ function reservation_status(r) {
         return 'revoked';
     else if(r.status_name==='已签到')
         return 'finished';
-    else if(r.status_name==='已预约') {
+    else if(r.status_name==='已预约' || r.status_name==='未签到') {
         let cur_time = +new Date();
         let d = period_text_to_date(parse_period_text(r.periodList));
         let sign_time = d ? (+d) : 0;

--- a/src/ui/ShuttleDetail.js
+++ b/src/ui/ShuttleDetail.js
@@ -35,7 +35,7 @@ export function ShuttleDetail({cell, close, navigate}) {
 
         let action_cmd = action_do_fn('预约', async ()=>{
             let res = await reserve(track.track_id, track.date, track.time_id);
-            if(is_time_nearby_for_signin(hhmm_to_int(cell.time_str)))
+            if(res && is_time_nearby_for_signin(hhmm_to_int(cell.time_str)))
                 navigate('qrcode', {type: 'reservation', reservation: {
                     res_id: res.appointment_id,
                     revokable: true,

--- a/userscript/gen_userscript.py
+++ b/userscript/gen_userscript.py
@@ -1,3 +1,7 @@
+# /// script
+# dependencies = ["brotli"]
+# ///
+
 import json
 from pathlib import Path
 import shutil


### PR DESCRIPTION
Add handling for new status name `未签到` which seems to be a synonym for `已预约`.